### PR TITLE
Fix automatic upgrade supervisor

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,3 +29,12 @@
     - deps
     - supervisor
     - supervisord
+
+- name: Mark Supervisord as hold
+  become: yes
+  when: ansible_os_family == 'Debian'
+  shell: apt-mark hold supervisor
+  tags:
+    - deps
+    - supervisor
+    - supervisord


### PR DESCRIPTION
Se deja el paquete supervisor en hold para evitar actualizaciones autmaticas y manuales por error